### PR TITLE
Add Ruby gem to list of Client Libraries

### DIFF
--- a/index.html
+++ b/index.html
@@ -514,8 +514,8 @@ The number of actual documents in the response. Can be less than the given <code
 </p>
 <ul>
 <li>Node: Matthew Chase Whittemore&#39;s <a href="https://npmjs.org/package/sunlight-congress-api">sunlight-congress-api</a> (unofficial)</li>
+<li>Ruby: Erik Michaels-Ober&#39;s <a href="http://rubygems.org/gems/congress">congress gem</a></li>
 <li>Python: Coming soon.</li>
-<li>Ruby: Coming soon.</li>
 </ul>
 <h2 id='other'>Other</h2 id='other'>
 <h3 id='other/migrating-from-our-old-sunlight-congress-api'>Migrating from our old Sunlight Congress API</h3 id='other/migrating-from-our-old-sunlight-congress-api'>


### PR DESCRIPTION
I recently updated this gem (version 0.1.0), which previously wrapped the Real Time Congress API, to support the new Sunlight Congress API.
