### PR TITLE
Add :number to title_summary_recency search profile fields.

### DIFF
--- a/models/bill.rb
+++ b/models/bill.rb
@@ -15,7 +15,7 @@ class Bill
     :nicknames, :summary, :keywords, :text
 
   search_profile :title_summary_recency,
-    fields: [:nicknames, :short_title, :summary],
+    fields: [:nicknames, :short_title, :summary, :number],
     filters: [
       {
         filter: {


### PR DESCRIPTION
A number of people appear to be searching for bill numbers without types. Adding the number field will surface the appropriate results.
