### PR TITLE
Remove number from title_summary_recency fields as it causes a type error

### DIFF
--- a/models/bill.rb
+++ b/models/bill.rb
@@ -15,7 +15,7 @@ class Bill
     :nicknames, :summary, :keywords, :text
 
   search_profile :title_summary_recency,
-    fields: [:nicknames, :short_title, :summary, :number],
+    fields: [:nicknames, :short_title, :summary],
     filters: [
       {
         filter: {


### PR DESCRIPTION
Going to handle this at the app level.
