### PR TITLE
If missing location data, change from 500 to 400

### DIFF
--- a/congress.rb
+++ b/congress.rb
@@ -98,7 +98,7 @@ end
 get(/(legislators|districts)\/locate\/?/) do
   check_key!
 
-  error 500, "Provide a 'zip', or a 'latitude' and 'longitude'." unless params[:zip] or (params[:latitude] and params[:longitude])
+  error 400, "Provide a 'zip', or a 'latitude' and 'longitude'." unless params[:zip] or (params[:latitude] and params[:longitude])
 
   begin
     if params[:zip]


### PR DESCRIPTION
Not supplying a required parameter (one of `latitude`, `longitude`, or `zip`) is a client error, not a server error, so this error should return a `400` status code.

/cc @drinks, and @sferik in case he has any reason to think this would mess up the `congress` gem.
