### PR TITLE
IG reports will fall back to landing_url if report is unreleased

### DIFF
--- a/tasks/ig_reports/ig_reports.rb
+++ b/tasks/ig_reports/ig_reports.rb
@@ -1,4 +1,3 @@
-require 'docsplit'
 
 class IgReports
 
@@ -78,7 +77,7 @@ class IgReports
               published_on: report_data['published_on'],
               posted_at: Utils.utc_parse(report_data['published_on']),
 
-              url: report_data['url'],
+              url: report_data['url'] || report_data['landing_url'],
               source_url: report_data['url'],
 
               ig_report: report_data


### PR DESCRIPTION
Now that we've tackled DOE and DOD, some IG reports may be `unreleased`, and not have a `url` field. This will cause the `ig_reports` task to fail. This makes the scraper fall back to `landing_url` to populate the API's `url` field. 

The IG report project is now enforcing that if the `url` is missing and `unreleased` is true, then `landing_url` must be populated. So this should be a safe bet.
