### PR TITLE
Formats mapping and removes first two levels

### DIFF
--- a/config/mappings/congressional_documents.json
+++ b/config/mappings/congressional_documents.json
@@ -1,102 +1,98 @@
 {
-	"congress": {
-		"mappings": {
-			"congressional_documents": {
-				"properties": {
-					"bill_id": {
-					"type": "string"
-					},
-					"bioguide_id": {
-					"type": "string"
-					},
-					"chamber": {
-					"type": "string"
-					},
-					"committee_id": {
-					"type": "string"
-					},
-					"committee_names": {
-					"type": "string"
-					},
-					"congress": {
-					"type": "long"
-					},
-					"description": {
-					"type": "string"
-					},
-					"document_id": {
-					"type": "string"
-					},
-					"document_type": {
-					"type": "string"
-					},
-					"hearing_title": {
-					"type": "string"
-					},
-					"hearing_type_code": {
-					"type": "string"
-					},
-					"house_event_id": {
-					"type": "long"
-					},
-					"occurs_at": {
-					"type": "date",
-					"format": "dateOptionalTime"
-					},
-					"published_at": {
-					"type": "date",
-					"format": "dateOptionalTime"
-					},
-					"subcommittee_suffix": {
-					"type": "string"
-					},
-					"text": {
-					"type": "string",
-					"term_vector": "with_positions_offsets"
-					},
-					"text_preview": {
-					"type": "string"
-					},
-					"type": {
-					"type": "string"
-					},
-					"urls": {
-					"properties": {
-					"permalink": {
-					"type": "string"
-					},
-					"url": {
-					"type": "string"
-					}
-					}
-					},
-					"version_code": {
-					"type": "string"
-					},
-					"witness": {
-					"properties": {
-					"first_name": {
-					"type": "string"
-					},
-					"last_name": {
-					"type": "string"
-					},
-					"middle_name": {
-					"type": "string"
-					},
-					"organization": {
-					"type": "string"
-					},
-					"position": {
-					"type": "string"
-					},
-					"witness_type": {
-					"type": "string"
-					}
-					}
-					}
-				}
-			}
-		}
-	}
+  "congressional_documents": {
+    "properties": {
+      "bill_id": {
+        "type": "string"
+      },
+      "bioguide_id": {
+        "type": "string"
+      },
+      "chamber": {
+        "type": "string"
+      },
+      "committee_id": {
+        "type": "string"
+      },
+      "committee_names": {
+        "type": "string"
+      },
+      "congress": {
+        "type": "long"
+      },
+      "description": {
+        "type": "string"
+      },
+      "document_id": {
+        "type": "string"
+      },
+      "document_type": {
+        "type": "string"
+      },
+      "hearing_title": {
+        "type": "string"
+      },
+      "hearing_type_code": {
+        "type": "string"
+      },
+      "house_event_id": {
+        "type": "long"
+      },
+      "occurs_at": {
+        "type": "date",
+        "format": "dateOptionalTime"
+      },
+      "published_at": {
+        "type": "date",
+        "format": "dateOptionalTime"
+      },
+      "subcommittee_suffix": {
+        "type": "string"
+      },
+      "text": {
+        "type": "string",
+        "term_vector": "with_positions_offsets"
+      },
+      "text_preview": {
+        "type": "string"
+      },
+      "type": {
+        "type": "string"
+      },
+      "urls": {
+        "properties": {
+          "permalink": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        }
+      },
+      "version_code": {
+        "type": "string"
+      },
+      "witness": {
+        "properties": {
+          "first_name": {
+            "type": "string"
+          },
+          "last_name": {
+            "type": "string"
+          },
+          "middle_name": {
+            "type": "string"
+          },
+          "organization": {
+            "type": "string"
+          },
+          "position": {
+            "type": "string"
+          },
+          "witness_type": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
I wasn't able to load the mapping unless I removed the first two levels (`congress` and `mappings`) -- it looks like those were attempting to update all mappings in the `congress` index at once.

This mapping begins at the collection-level:

``` json
{
  "congressional_documents": {
    "properties": {
      "bill_id": {
        "type": "string"
      },
  ...
}
```

And is in line with the other mappings in `config/mappings/`.

I also ran the JSON through a JSON formatter to normalize the tabs to be more readable, and to match the other mappings.

This can now be loaded using the rake task. The first run with `force=1` notes that the index already exists, and then notes (for me, locally) that the mapping didn't need to be deleted because it doesn't exist, and then correctly indexes the mapping.

```
$ rake elasticsearch:init force=1 only=congressional_documents

running: curl -XPUT 'http://127.0.0.1:9200/congress'
{"error":"IndexAlreadyExistsException[[congress] already exists]","status":400}
Ensured index exists

running: curl -XDELETE 'http://127.0.0.1:9200/congress/_mapping/congressional_documents/'
{"error":"TypeMissingException[[_all] type[[congressional_documents]] missing: No index has the type.]","status":404}
Deleted congressional_documents

running: curl -XPUT 'http://127.0.0.1:9200/congress/_mapping/congressional_documents' -d @config/mappings/congressional_documents.json
{"acknowledged":true}
Created congressional_documents
```

If re-running with the same parameters, it correctly drops and re-loads the mapping (which drops all data in the collection):

```
$ rake elasticsearch:init force=1 only=congressional_documents

running: curl -XPUT 'http://127.0.0.1:9200/congress'
{"error":"IndexAlreadyExistsException[[congress] already exists]","status":400}
Ensured index exists

running: curl -XDELETE 'http://127.0.0.1:9200/congress/_mapping/congressional_documents/'
{"acknowledged":true}
Deleted congressional_documents

running: curl -XPUT 'http://127.0.0.1:9200/congress/_mapping/congressional_documents' -d @config/mappings/congressional_documents.json
{"acknowledged":true}
Created congressional_documents
```

The mapping can be verified by visiting `http://localhost:9200/congress/congressional_documents/_mapping` in your browser.
