### PR TITLE
Some formatting fixes and copy fixes

### DIFF
--- a/congressional_documents.md
+++ b/congressional_documents.md
@@ -8,10 +8,9 @@ layout: default
 
 # Congressional Documents
 
-Currently, this project covers recent documents in the [House Committee Repository](http://docs.house.gov/Committee/Committees.aspx).  
+Currently, this project covers recent documents in the [House Committee Repository](http://docs.house.gov/Committee/Committees.aspx).
 
 The information is sourced from the bulk data at [github.com/unitedstates](https://github.com/unitedstates/congress). Feel free to [open a ticket](https://github.com/unitedstates/congress/issues/new) with any bugs or suggestions.
-
 
 ## Methods
 
@@ -31,21 +30,23 @@ This collection contains documents from from Congress that are produced through 
 A unique id for each document.
 
 **document_type**
-Document types are taken from the House document type code- 
-```
+Document types are taken from the House document type code-
+
+{% highlight json %}
 {
 	"CV": "Committee vote",
-	"WS": "Witness statement", 
-	"WT": "Witness truth statement", 
-	"WB": "Witness biography", 
-	"CR": "Committee report", 
-	"BR": "Bill", 
+	"WS": "Witness statement",
+	"WT": "Witness truth statement",
+	"WB": "Witness biography",
+	"CR": "Committee report",
+	"BR": "Bill",
 	"FA": "Floor amendment",
-	"CA": "Committee amendment", 
-	"HT": "Transcript", 
+	"CA": "Committee amendment",
+	"HT": "Transcript",
 	"WD": "Witness document",
 }
-```
+{% endhighlight %}
+
 "other" is used for all other documents.
 
 **chamber**
@@ -61,10 +62,10 @@ Full names of the committees associated with the document.
 Session of Congress.
 
 **house_event_id**
-Unique id for each hearing, assigned by the House.
+Unique ID for each hearing, assigned by the House.
 
 **hearing_type_code**
-This describes if the meeting is a markup, meeting or hearing.
+This describes if the meeting is a "markup", "meeting" or "hearing".
 
 **hearing_title**
 Title of the hearing associated with the document.
@@ -73,39 +74,39 @@ Title of the hearing associated with the document.
 Date and time of publication.
 
 **bill_id**
-Bill ID associated with the document. 
+Bill ID associated with the document.
 
 **description**
 Description of the hearing.
 
 **version_code**
-The short-code for what stage the version of the bill. See [GPO](http://www.gpo.gov/help/about_congressional_bills.htm) for explanations for the version code.
+The short-code for what stage the version of the bill. See [GPO](http://www.gpo.gov/help/about_congressional_bills.htm) for explanations of the version code.
 
 **bioguide_id**
 Unique identifier for a member of Congress if they are associated with the document.
 
 **occurs_at**
-Date and time of a hearing associated with the document. 
+Date and time of a hearing associated with the document.
 
 **urls**
-The original link to the document. The permalink is a link to a copy of the document hosted by the Sunlight Foundation. 
+The original link to the document. The permalink is a link to a copy of the document hosted by the Sunlight Foundation.
 
 **text**
 Extracted text from the document.
 
 **text_preview**
-A preview of the text. 
+A preview of the text.
 
 **witness**
 Information about a witness associated with a document.
 
-```
-	{
-		position: "Director",
-		witness_type: "Government - State",
-		first_name: "Steve",
-		organization: "Texas Department of Public Safety",
-		middle_name: null,
-		last_name: "McCraw"
-	},
-```
+{% highlight json %}
+{
+  "position": "Director",
+  "witness_type": "Government - State",
+  "first_name": "Steve",
+  "organization": "Texas Department of Public Safety",
+  "middle_name": null,
+  "last_name": "McCraw"
+}
+{% endhighlight %}

--- a/documents.md
+++ b/documents.md
@@ -2,18 +2,18 @@
 layout: default
 ---
 
-
 * placeholder
 {:toc}
 
 # Documents
 
-This project covers a wide range of documents including Government Accountability Office (GAO) Reports and Inspector General Reports. These government oversight documents investigate misconduct, waste and programs. 
+This project covers a wide range of documents including Government Accountability Office (GAO) Reports and Inspector General Reports. These government oversight documents investigate misconduct, waste and programs.
 
-The Inspector General data is fueled by an amazing volunteer effort that is part of the [@unitedstates](http://theunitedstates.io/) project. These volunteers built scrapers for all 65 US federal inspectors. Check the [inspectors-general](https://github.com/unitedstates/inspectors-general) repo to see the scrapers that are currently running or, learn how to contribute to the project. Feel free to [open a ticket](https://github.com/unitedstates/inspectors-general/issues/new) with any bugs or suggestions.
+The Inspector General data is fueled by an amazing volunteer effort that is part of the [@unitedstates](http://theunitedstates.io/) project. These volunteers built scrapers for all 65 US federal inspectors that publish reports online.
 
-GAO reports come from the GAO's API
+Check the [inspectors-general](https://github.com/unitedstates/inspectors-general) repo to see the scrapers that are currently running or, learn how to contribute to the project. Feel free to [open a ticket](https://github.com/unitedstates/inspectors-general/issues/new) with any bugs or suggestions.
 
+GAO reports come from the [official GAO website](http://www.gao.gov/).
 
 ## Methods
 
@@ -27,116 +27,117 @@ https://congress.api.sunlightfoundation.com
 
 This provides full-text search for oversight documents. [See the /congressional-documents method for congressional documents](congressiona_documents.md).
 
-***document_type***
-This includes gao_reports 
+**document_type**
+"gao_report", or "ig_report".
 
-***document_type_name***
-This includes "GAO Reports" and "Inspector General Report"
+**document_type_name**
+This includes "GAO Reports" and "Inspector General Report".
 
-***posted_at***
-Release date of the document
+**posted_at**
+Release date of the document.
 
-***published_on***
-Date the document was published
+**published_on**
+Date the document was published.
 
-***title***
-Title of the document
+**title**
+Title of the document.
 
-***categories***
+**categories**
 Kind of document as assigned by the GAO.
 
-***url***
+**url**
 Landing page for the document or link to the document if no landing page.
 
-***source_url***
+**source_url**
 The document's url.
 
 ### Fields for gao_reports:
 
-***gao_id***
+**gao_id**
 Identifier for the document used in the web address on the GAO website.
 
-***report_number***
+**report_number**
 GAO report number.
 
-***supplement_url***
+**supplement_url**
 URL for supplemental information.
 
-***youtube_id***
+**youtube_id**
 Youtube id if one is associated with the document.
 
-***links***
+**links**
 Additional links related to the document.
 
-***description***
-Description of the document
+**description**
+Description of the document.
 
-```
-gao_report: {
-	report_number: "GAO-13-126R",
-	description: "What GAO Found...",
-	gao_id: "649883",
-	supplement_url: null,
-	links: null,
-	youtube_id: null
-},
-```
+{% highlight json %}
+"gao_report": {
+  "report_number": "GAO-13-126R",
+  "description": "What GAO Found...",
+  "gao_id": "649883",
+  "supplement_url": null,
+  "links": null,
+  "youtube_id": null
+}
+{% endhighlight %}
+
 ### Fields for ig_report
 
-***inspector_url***
+**inspector_url**
 The url of the Inspector General that created the report. Inspector Generals are located withing their respective departments.
 
-***pdf***
+**pdf**
 Metadata from the PDF. Including modification_date, creation_date, author and page_count.
 
-***published_on***
+**published_on**
 Document's publication date.
 
-***agency***
+**agency**
 Shortened name of the agency that produced the report.
 
-***agency_name***
+**agency_name**
 Full agency name.
 
-***type***
+**type**
 General category that identifies the file as a report, audit, etc.
 
-***url***
+**url**
 The report's URL.
 
-***file_type***
-File type of the document, most reports are PDF. 
+**file_type**
+File type of the document, most reports are PDF.
 
-***title***
+**title**
 The title of the report.
 
-***report_id***
+**report_id**
 A unique identifier for the report.
 
-***year***
+**year**
 Year of the report.
 
-```
-ig_report: {
-	topic: "Other",
-	inspector_url: "http://www.doi.gov/oig/",
-	inspector: "interior",
-	pdf: {
-		modification_date: "2014-01-30",
-		creation_date: "2014-01-30",
-		author: "Khadiagala, Lynn",
-		page_count: 24
-	},
-	published_on: "2014-01-30",
-	agency: "interior",
-	type: "report",
-	agency_name: "Department of the Interior",
-	url: "http://www.doi.gov/oig/reports/upload/OIGOrganizationalAssessment13Public.pdf",
-	file_type: "pdf",
-	title: "Office of Inspector General Organizational Assessment 2013",
-	report_id: "OIGOrganizationalAssessment13Public",
-	year: 2014
-},
-```
+{% highlight json %}
+"ig_report": {
+  "topic": "Other",
+  "inspector_url": "http://www.doi.gov/oig/",
+  "inspector": "interior",
+  "pdf": {
+    "modification_date": "2014-01-30",
+    "creation_date": "2014-01-30",
+    "author": "Khadiagala, Lynn",
+    "page_count": 24
+  },
+  "published_on": "2014-01-30",
+  "agency": "interior",
+  "type": "report",
+  "agency_name": "Department of the Interior",
+  "url": "http://www.doi.gov/oig/reports/upload/OIGOrganizationalAssessment13Public.pdf",
+  "file_type": "pdf",
+  "title": "Office of Inspector General Organizational Assessment 2013",
+  "report_id": "OIGOrganizationalAssessment13Public",
+  "year": 2014
+}
+{% endhighlight %}
 
 Other fields may appear for particular inspectors. These fields vary by inspector and are experimental.


### PR DESCRIPTION
This fixes up some JSON formatting and highlighting, makes some minor copy tweaks, and describes the GAO source more precisely.

Unfortunately, Sunlight's Jekyll configuration cannot do fenced backticks (```) for highlighting, the docs use Liquid syntax (`{% highlight json %}`) instead.
