### PR TITLE
gao scraper now checks 30days back

### DIFF
--- a/tasks/gao_reports/gao_reports.rb
+++ b/tasks/gao_reports/gao_reports.rb
@@ -18,9 +18,12 @@ class GaoReports
       if options[:year]
         beginning = Time.parse("#{options[:year]}-01-01").midnight
         ending = Time.parse("#{options[:year]}-12-31").midnight
+      elsif options[:month]
+        beginning = Time.parse("#{options[:month]}-01").midnight
+        ending = Time.parse("#{options[:month]}-31").midnight
       else
         ending = Time.now.midnight
-        beginning = ending - 7.days
+        beginning = ending - 30.days
       end
 
       gao_ids = gao_ids_for beginning, ending, options


### PR DESCRIPTION
we were missing some GAO documents, presumably due to the scraper's lookback not being long enough to deal with failures and downtime? I'm changing the default to 30 days, and I reran the scraper for the past year on the server to catch up.
